### PR TITLE
Small fix php exception for uploaded gif images

### DIFF
--- a/src/Image.php
+++ b/src/Image.php
@@ -35,7 +35,7 @@ class Image
         $image = new static($class::createFromFile($image), $image);
 
         if ($image->getMimeType() === 'image/gif') {
-            $stream = fopen($image, 'rb');
+            $stream = fopen($image->filename, 'rb');
 
             if (self::isAnimatedGif($stream)) {
                 $image->image->setAnimated(true);


### PR DESCRIPTION
Small fix for uploaded gif images. Exception:

'ErrorException' with message 'fopen() expects parameter 1 to be a valid path, object given'