### PR TITLE
crop: fixed crop method comparison when $x offset passed as int

### DIFF
--- a/src/Image.php
+++ b/src/Image.php
@@ -325,11 +325,8 @@ class Image
 
         list($width, $height) = $this->calculateClientSize($width, $height);
 
-        switch ($x) {
-            case self::CROP_BALANCED:
-            case self::CROP_ENTROPY:
-            case self::CROP_FACE:
-                list($x, $y) = $this->image->getCropOffsets($width, $height, $x);
+        if (in_array($x, [self::CROP_BALANCED, self::CROP_ENTROPY, self::CROP_FACE], true)) {
+            list($x, $y) = $this->image->getCropOffsets($width, $height, $x);
         }
 
         $x = Dimmensions::getPositionValue('x', $x, $width, $imageWidth);


### PR DESCRIPTION
If x is passed as an int, crop_* constancs are converted to int -> 0 and the comparison match the case.