### PR TITLE
Fix Imagick setProgressive()

### DIFF
--- a/src/Libs/Imagick.php
+++ b/src/Libs/Imagick.php
@@ -363,9 +363,9 @@ class Imagick extends AbstractLib implements LibInterface
     public function setProgressive($progressive)
     {
         if ($progressive) {
-            $this->image->setInterlaceScheme(Imagick::INTERLACE_PLANE);
+            $this->image->setInterlaceScheme(BaseImagick::INTERLACE_PLANE);
         } else {
-            $this->image->setInterlaceScheme(Imagick::INTERLACE_NO);
+            $this->image->setInterlaceScheme(BaseImagick::INTERLACE_NO);
         }
     }
 }


### PR DESCRIPTION
BaseImagick must be used to access INTERLACE_PLANE and INTERLACE_NO constants

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarotero/imagecow/31)
<!-- Reviewable:end -->
