### PR TITLE
fix the GD rotates GIF image background color

### DIFF
--- a/src/Libs/Gd.php
+++ b/src/Libs/Gd.php
@@ -67,7 +67,6 @@ class Gd extends AbstractLib implements LibInterface
 
         imagealphablending($this->image, true);
         imagesavealpha($this->image, true);
-        imagesetinterpolation($this->image, IMG_BICUBIC);
     }
 
     /**
@@ -273,6 +272,8 @@ class Gd extends AbstractLib implements LibInterface
         if ($background === false || ($image = imagerotate($this->image, -$angle, $background)) === false) {
             throw new ImageException('Error rotating the image');
         }
+
+        imagecolortransparent($image, imagecolorallocatealpha($image, 0, 0, 0, 127));
 
         imagedestroy($this->image);
         $this->image = $image;

--- a/src/Libs/Imagick.php
+++ b/src/Libs/Imagick.php
@@ -276,7 +276,7 @@ class Imagick extends AbstractLib implements LibInterface
      */
     public function rotate($angle)
     {
-        if ($this->image->rotateImage(new BaseImagickPixel(), $angle) !== true) {
+        if ($this->image->rotateImage(new BaseImagickPixel('#FFFFFF'), $angle) !== true) {
             throw new ImageException('There was an error rotating the image');
         }
 


### PR DESCRIPTION
# Changed log
- It fixes this issue #35 .
- Set the default interpolation method because using the ```IMG_BICUBIC``` method will cause the rotated GIF image of background is not the transparent background.
- I also fix the Imagick rotates the transparent background image issue :smile: .